### PR TITLE
API config now makes use of oc_config

### DIFF
--- a/coin-api-dist/src/main/resources/tomcat/coin-api.properties.vm
+++ b/coin-api-dist/src/main/resources/tomcat/coin-api.properties.vm
@@ -21,28 +21,28 @@
 ##
 ####################################################################
 
-janus.user=engine
-janus.secret=engineblock
 janus.uri=https://serviceregistry._OPENCONEXT_DOMAIN_/simplesaml/module.php/janus/services/rest/
+janus.user=_OC__API_JANUSAPI_USER_
+janus.secret=_OC__API_JANUSAPI_PASS_
 
 coin-api.jdbc.driver=com.mysql.jdbc.Driver
 coin-api.jdbc.url=jdbc:mysql://localhost:3306/api
-coin-api.jdbc.user=root
-coin-api.jdbc.password=c0n3xt
+coin-api.jdbc.user=_OC__API_DB_USER_
+coin-api.jdbc.password=_OC__API_DB_PASS_
 
 coin-api.ldap.url=ldap://localhost:389
-coin-api.ldap.password=ks97THqW2m3BN
-coin-api.ldap.userDn=cn=ro,dc=surfconext,dc=nl
+coin-api.ldap.password=_OC__LDAP_PASS_
+coin-api.ldap.userDn=_OC__LDAP_USER_
 
 coin-api.engineblock.jdbc.driver=com.mysql.jdbc.Driver
-coin-api.engineblock.jdbc.password=c0n3xt
 coin-api.engineblock.jdbc.url=jdbc:mysql://localhost:3306/engineblock
-coin-api.engineblock.jdbc.user=root
+coin-api.engineblock.jdbc.password=_OC__ENGINE_DB_PASS_
+coin-api.engineblock.jdbc.user=_OC__ENGINE_DB_USER_
 
 coin-api.teams.jdbc.driver=com.mysql.jdbc.Driver
 coin-api.teams.jdbc.url=jdbc:mysql://localhost:3306/teams
-coin-api.teams.jdbc.user=root
-coin-api.teams.jdbc.password=c0n3xt
+coin-api.teams.jdbc.user=_OC__TEAMS_DB_USER_
+coin-api.teams.jdbc.password=_OC__TEAMS_DB_PASS_
 
 # global configuration of database properties, used for all data sources
 # in seconds


### PR DESCRIPTION
The changes in this pull request allow the OpenConext VM to fill the API config files with sensible values
